### PR TITLE
DS-83-4 Protect edge cases of dummy var adj

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.1.17
+Version: 1.1.18
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/R/regression.R
+++ b/R/regression.R
@@ -654,11 +654,13 @@ Regression <- function(formula = as.formula(NULL),
                 stop("Dummy variable adjustment method for missing data is not supported for categorical predictor ",
                      "variables in ", output, ". Please remove the categorical predictors: ",
                      paste0(names(classes), collapse = ", "), " and re-run the analysis.")
-            .estimation.data <- adjustDataMissingDummy(data, result$original, .estimation.data, interaction.name = interaction.name)
-            input.formula <- updateDummyVariableFormulae(formula = input.formula, formula.with.interaction = NULL,
-                                                         data = processed.data$estimation.data,
-                                                         update.string = " - ",
-                                                         warn = FALSE)$formula
+            if (any(grepDummyVars(names(result$original$coefficients))))
+            {
+                .estimation.data <- adjustDataMissingDummy(data, result$original, .estimation.data, interaction.name = interaction.name)
+                input.formula <- updateDummyVariableFormulae(formula = input.formula, formula.with.interaction = NULL,
+                                                             data = processed.data$estimation.data,
+                                                             update.string = " - ")$formula
+            }
             result$formula <- input.formula
         }
 
@@ -1678,15 +1680,10 @@ updateStackedFormula <- function(data, formula)
 # The control to add or remove is via the update.string argument, " + " adds to the formulae
 # while " - " removes dummy variables from the formulae
 updateDummyVariableFormulae <- function(formula, formula.with.interaction, data,
-                                        update.string = " + ", warn = TRUE)
+                                        update.string = " + ")
 {
     if (!any(dummy.vars <- grepDummyVars(names(data))))
-    {
-        if (warn)
-            warning("'Dummy variable adjustment' selected to handle missing data ",
-                    "but no missing values appear in the predictors")
         return(list(formula = formula, formula.with.interaction = formula.with.interaction))
-    }
 
     dummy.var <- paste0(names(data)[dummy.vars], collapse = update.string)
     new.formula <- update(terms(formula, data = data), as.formula(paste0(". ~ .", update.string, dummy.var)))

--- a/tests/testthat/test-dummyvariableadjustment.R
+++ b/tests/testthat/test-dummyvariableadjustment.R
@@ -115,3 +115,10 @@ test_that("Robust SE compatible with Dummy variable adjustment", {
     expect_warning(print(robust.dummy.regression), "Unusual observations detected")
 })
 
+
+test_that("RIA and Shapley edge case", {
+    dat <- not.missing.data
+    dat[sample(c(TRUE, FALSE), size = nrow(dat), replace = TRUE, prob = c(1, 4)), -1] <- NA
+    expect_error(Regression(Y ~ X1 + X2 + X3, data = dat, type = "Linear", output = "Shapley Regression"),
+                 NA)
+})


### PR DESCRIPTION
Calls to `adjustDataMissingDummy` are protected against the case that there are
no dummy variables. Warnings also removed since information is given in
the caption now.