### PR TITLE
DS-2826 Update VIF warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.2.3
+Version: 1.2.4
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/tests/testthat/test-warnings.R
+++ b/tests/testthat/test-warnings.R
@@ -121,9 +121,110 @@ test_that("Removed aliased predictors (ordered logit)",
                              fixed = TRUE)
           })
 
+data(bank, package = "flipExampleData")
 test_that("No VIF warning with dummy variables", {
-    data(bank, package = "flipExampleData")
     z <- Regression(Overall ~ Fees + ATM + Branch, data = bank, missing = "Dummy variable adjustment")
     expect_warning(print(z), paste0("Unusual observations detected"), fixed = TRUE)
 })
 
+test_that("DS-2826: Warnings for VIFs are improved and appropriate", {
+    set.seed(123)
+    X <- MASS::mvrnorm(n = 100, mu = c(1, 5, 6), Sigma = matrix(c(1, 0.4, 0.9,
+                                                                  0.4, 1, 0.5,
+                                                                  0.9, 0.5, 1),
+                                                                nrow = 3, byrow = TRUE))
+    beta <- c(5, 1, 2, 3)
+    Y <- cbind(rep(1, nrow(X)), X) %*% beta + rnorm(100, sd = 1)
+    dat <- data.frame(Y, X)
+    model <- Regression(Y ~ ., data = dat)
+    expect_warning(flipRegression:::checkVIFAndWarn(model),
+                   paste0("A high Variance Inflation Factor is observed in the coefficients X3 = 5.7; X1 = 5.2. ",
+                          "A value of 4 or more indicates the confidence interval for the coefficient is twice as ",
+                          "wide as they would be for uncorrelated predictors. A value of 10 or more indicates high ",
+                          "multicollinearity. Consider conducting a relative importance analysis by selecting the ",
+                          "output to be Relative Importance Analysis or Shapley Regression."),
+                   fixed = TRUE)
+    # Consider glm and expect suggestion to not include Shapley
+    dat.poisson <- dat
+    dat.poisson$Y <- round(dat.poisson$Y)
+    poisson.model <- Regression(Y ~ ., type = "Poisson", data = dat.poisson)
+    expect_warning(flipRegression:::checkVIFAndWarn(poisson.model),
+                   paste0("A high Variance Inflation Factor is observed in the coefficients X3 = 5.7; X1 = 5.2. ",
+                          "A value of 4 or more indicates the confidence interval for the coefficient is twice as ",
+                          "wide as they would be for uncorrelated predictors. A value of 10 or more indicates high ",
+                          "multicollinearity. Consider conducting a relative importance analysis by selecting the ",
+                          "output to be Relative Importance Analysis."),
+                   fixed = TRUE)
+    # Expect VIF cacluation to be skipped an no warning for RIA
+    for (ria in c("Relative Importance Analysis", "Shapley Regression"))
+    {
+        ria.model <- Regression(Y ~ X1 + X2 + X3, output = ria, data = dat)
+        warning.msg <- capture_warnings(print(ria.model))
+        expect_true(length(warning.msg) == 1)
+        expect_true(grepl("^Unusual observations detected", warning.msg))
+        expect_false(grepl("Variation Inflation Factor", warning.msg))
+    }
+    # Add metadata to variable labels
+    createMetaData <- function(variable, question, label)
+    {
+        attr(variable, "question") <- question
+        attr(variable, "label") <- label
+        variable
+    }
+    dat.named <- data.frame(mapply(createMetaData,
+                                   dat,
+                                   c("Outcome", rep("Predictor", 3)),
+                                   c("response", LETTERS[1:3]),
+                                   SIMPLIFY = FALSE))
+    model.with.labels <- Regression(Y ~ ., data = dat.named, show.labels = TRUE)
+    expect_warning(flipRegression:::checkVIFAndWarn(model.with.labels),
+                   paste0("A high Variance Inflation Factor is observed in the coefficients C = 5.7; A = 5.2. ",
+                          "A value of 4 or more indicates the confidence interval for the coefficient is twice as ",
+                          "wide as they would be for uncorrelated predictors. A value of 10 or more indicates high ",
+                          "multicollinearity. Consider conducting a relative importance analysis by selecting the ",
+                          "output to be Relative Importance Analysis or Shapley Regression."),
+                   fixed = TRUE)
+    # Expect no warning when VIF is low
+    set.seed(12321)
+    X <- MASS::mvrnorm(n = 100, mu = c(1, 5, 6), Sigma = matrix(c(1, 0.4, 0.2,
+                                                                  0.4, 1, 0.5,
+                                                                  0.2, 0.5, 1),
+                                                                nrow = 3, byrow = TRUE))
+    beta <- c(5, 1, 2, 3)
+    Y <- cbind(rep(1, nrow(X)), X) %*% beta + rnorm(100, sd = 1)
+    dat <- data.frame(Y, X)
+    model.with.low.vif <- Regression(Y ~ ., data = dat)
+    expect_warning(flipRegression:::checkVIFAndWarn(model.with.low.vif), NA)
+    # Check Generalised VIF using a factor
+    X4 <- cut(dat$X2, breaks = c(0, 4, 6, Inf), labels = LETTERS[1:3])
+    beta <- c(beta, 2)
+    Y <- cbind(rep(1, nrow(X)), as.matrix(dat[-1]), as.numeric(X4)) %*% beta + rnorm(100, sd = 1)
+    original.dat <- dat
+    dat <- data.frame(Y, X)
+    dat$X4 <- X4
+    model.with.vgif <- Regression(Y ~ ., data = dat)
+    expect_warning(flipRegression:::checkVIFAndWarn(model.with.vgif),
+                   paste0("A high squared Generalized Variance Inflation Factor is observed in the coefficient for X2 = 4.9. ",
+                          "A value of 4 or more indicates the confidence interval for the coefficient is ",
+                          "twice as wide as they would be for uncorrelated predictors. A value of 10 or more ",
+                          "indicates high multicollinearity. Consider conducting a relative importance analysis by ",
+                          "selecting the output to be Relative Importance Analysis or Shapley Regression."),
+                   fixed = TRUE)
+    # Check the warnings with Dummy variable adjustment
+    # Make 40% missing in X1 and make 90% in common with X2 missing
+    dat <- original.dat
+    n.dat <- nrow(dat)
+    x1.missing <- rep(c(TRUE, FALSE), c(40, 60))
+    x2.missing <- rep(c(TRUE, FALSE), c(36, 64))
+    dat$X1[x1.missing] <- NA
+    dat$X2[x2.missing] <- NA
+    dummy.model <- Regression(Y ~ ., data = dat, missing = "Dummy variable adjustment")
+    expect_warning(flipRegression:::checkVIFAndWarn(dummy.model),
+                   paste0("A high Variance Inflation Factor for the added dummy variables are observed in the ",
+                          "coefficients X1 = 6.5; X2 = 6.5. A value of 4 or more indicates the confidence ",
+                          "interval for the coefficient is twice as wide as they would be for uncorrelated ",
+                          "predictors. A value of 10 or more indicates high multicollinearity. Consider ",
+                          "conducting a relative importance analysis by selecting the output to be Relative ",
+                          "Importance Analysis or Shapley Regression."),
+                   fixed = TRUE)
+})


### PR DESCRIPTION
VIF warnings have been updated to be checked for all regression outputs
except Relative Importance Analysis or Shapley. Previous it was only
checked for type = "Linear". Also the Generalized VIF values returned
from car are handled properly and squared to keep the equivalent rule of
thumb boundaries. Finally the coefficient names have been replaced with
labels and tidied if necessary. Unit tests added to cover all the above
comments.