### PR TITLE
DS-2964-2 Fix alignment in stacking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.18
+Version: 1.3.17
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.17
+Version: 1.3.18
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.16
+Version: 1.3.17
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/R/regression.R
+++ b/R/regression.R
@@ -1757,10 +1757,10 @@ checkStackAlignment <- function(data, outcome.names, predictor.names)
 stackData <- function(data)
 {
     outcome.names <- getMultiOutcomeNames(data[["Y"]])
-    stacked.outcome <- stackOutcome(data[["Y"]])
+    stacked.outcome <- stackOutcome(data[["Y"]], outcome.names)
     stacked.predictors <- stackPredictors(data[["X"]], outcome.names)
     if (!all(row.names(stacked.outcome) == row.names(stacked.predictors)))
-        stop("Stacked variables were not aligned properly. Contact support for further help")
+        stop("Stacked variables are not aligned properly. Contact support for further help.")
     stacked.data <- cbind(stacked.outcome, stacked.predictors)
     return(stacked.data)
 }
@@ -1796,11 +1796,11 @@ stackPredictors <- function(data, outcome.names)
 }
 
 #' @importFrom stats reshape
-stackOutcome <- function(data)
+stackOutcome <- function(data, outcome.names)
 {
     v.name <- if (!is.null(question.attr <- attr(data ,"question"))) question.attr else "Y"
     stacked.data <- reshape(data, varying = names(data), v.names = v.name,
-                            times = names(data), direction = "long")
+                            times = outcome.names, direction = "long")
     stacked.data <- removeReshapingHelperVariables(stacked.data)
     stacked.data <- addLabelAttribute(stacked.data)
     names(stacked.data) <- "Y"

--- a/R/regression.R
+++ b/R/regression.R
@@ -1744,6 +1744,10 @@ checkStackAlignment <- function(data, outcome.names, predictor.names)
     {
         new.column.order <- match(outcome.names, predictor.names)
         tmp <- data[["Y"]]
+        if (!is.null(attr(tmp, "secondarycodeframe")))
+            attr(tmp, "secondarycodeframe") <- attr(tmp, "secondarycodeframe")[new.column.order]
+        else if (!is.null(attr(tmp, "codeframe")))
+            attr(tmp, "codeframe") <- attr(tmp, "codeframe")[new.column.order]
         data[["Y"]] <- data[["Y"]][new.column.order]
         data[["Y"]] <- CopyAttributes(data[["Y"]], tmp)
     }

--- a/R/regression.R
+++ b/R/regression.R
@@ -1759,6 +1759,8 @@ stackData <- function(data)
     outcome.names <- getMultiOutcomeNames(data[["Y"]])
     stacked.outcome <- stackOutcome(data[["Y"]])
     stacked.predictors <- stackPredictors(data[["X"]], outcome.names)
+    if (!all(row.names(stacked.outcome) == row.names(stacked.predictors)))
+        stop("Stacked variables were not aligned properly. Contact support for further help")
     stacked.data <- cbind(stacked.outcome, stacked.predictors)
     return(stacked.data)
 }

--- a/R/regression.R
+++ b/R/regression.R
@@ -1742,7 +1742,7 @@ checkStackAlignment <- function(data, outcome.names, predictor.names)
 {
     if (!identical(outcome.names, predictor.names))
     {
-        new.column.order <- match(outcome.names, predictor.names)
+        new.column.order <- match(predictor.names, outcome.names)
         tmp <- data[["Y"]]
         if (!is.null(attr(tmp, "secondarycodeframe")))
             attr(tmp, "secondarycodeframe") <- attr(tmp, "secondarycodeframe")[new.column.order]
@@ -1842,7 +1842,7 @@ getGridNames <- function(data)
     } else
     {
         split.names <- strsplit(names(data), ", ")
-        splits <- sapply(split.names, length)
+        splits <- vapply(split.names, length, numeric(1))
         if (any(ambiguous.splits <- splits != 2))
             stop("The variable labels in the predictor grid should be comma separated to determine the columns ",
                  "that belong to the appropriate outcome variable. This means that the variable labels cannot ",


### PR DESCRIPTION
Previous code didnt handle the data stacking properly when the variables 
between the outcome and predictor grids were in a different order. This 
commit fixes this and adds checks and tests to ensure the alignment is 
correct.

- DS-2964 Update stack alignment function
- DS-2964 Ensure codeframe updated in alignment check
- DS-2964 Error thrown
- DS-2964 Add unit test for stack alignment
- fixup! DS-2964 Add unit test for stack alignment
