### PR TITLE
DS-2986 Handle Aliased Dummy variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
   - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev
+  - export flipData_BRANCH_NAME=DS-2986
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="n.fail <- as.numeric(sub('Failed:[[:space:]]', '', out[grep('Failed:[[:space:]]', out)])); "
   - rcode+="res <- as.data.frame(res); out <- data.frame(file = unlist(res[['file']]), warning = unlist(res[['warning']])); "

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
   - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev
-  - export flipData_BRANCH_NAME=DS-2986
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="n.fail <- as.numeric(sub('Failed:[[:space:]]', '', out[grep('Failed:[[:space:]]', out)])); "
   - rcode+="res <- as.data.frame(res); out <- data.frame(file = unlist(res[['file']]), warning = unlist(res[['warning']])); "
@@ -28,6 +27,7 @@ r_packages:
 r_github_packages:
   - Displayr/flipDevTools
   - Displayr/flipExampleData
+  - Displayr/flipData@DS-2986
 
 script:
   - R CMD build --no-manual --no-build-vignettes --no-resave-data .

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ r_packages:
 r_github_packages:
   - Displayr/flipDevTools
   - Displayr/flipExampleData
-  - Displayr/flipData@DS-2986
+  - Displayr/flipData
 
 script:
   - R CMD build --no-manual --no-build-vignettes --no-resave-data .

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.18
+Version: 1.3.20
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.
@@ -13,7 +13,7 @@ Imports:
     car,
     effects,
     flipFormat (>= 1.7.0),
-    flipData (>= 1.2.5),
+    flipData (>= 1.2.11),
     flipTables (>= 2.0.0),
     flipStandardCharts,
     flipStatistics (>= 1.0.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
     robustbase
 Remotes: Displayr/flipU,
     Displayr/flipFormat,
-    Displayr/flipData,
+    Displayr/flipData@DS-2986,
     Displayr/flipStandardCharts,
     Displayr/flipStatistics,
     Displayr/flipTransformations,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
     robustbase
 Remotes: Displayr/flipU,
     Displayr/flipFormat,
-    Displayr/flipData@DS-2986,
+    Displayr/flipData,
     Displayr/flipStandardCharts,
     Displayr/flipStatistics,
     Displayr/flipTransformations,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.21
+Version: 1.3.19
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.20
+Version: 1.3.21
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project conventions.

--- a/R/regression.R
+++ b/R/regression.R
@@ -2000,7 +2000,7 @@ aliasedDummyVariableWarning <- function(data, mapping.variables, show.labels, pr
         groups <- lapply(1:n.groups, function(x) paste0("Group ", x, " (", groups[[x]], ")"))
         groups <- unlist(groups)
         group.msg <- paste0(paste0(groups[1:(n.groups - 1)], collapse = ", "), " and ", groups[n.groups])
-        warning.msg <- paste0("Some groups of predictors have the exactly the same cases with ",
+        warning.msg <- paste0("Some groups of predictors have exactly the same cases with ",
                               "missing values and consequently, only a single dummy variable was ",
                               "used to adjust the data for each group. ", group.msg, ". The dummy ",
                               "variables would be aliased if each predictor in each group had ",

--- a/R/regression.R
+++ b/R/regression.R
@@ -481,17 +481,28 @@ Regression <- function(formula = as.formula(NULL),
             final.model <- setChartData(final.model, output)
             return(final.model)
         }
+        unfiltered.weights <- processed.data$unfiltered.weights
+        .estimation.data <- processed.data$estimation.data
 
         if (missing == "Dummy variable adjustment")
         {
+            # Check for aliased dummy variables
+            dummy.variables <- names(.estimation.data)[grepDummyVars(names(.estimation.data))]
+            predictor.names <- names(.estimation.data)[-which(names(.estimation.data) == outcome.name)]
+            mapping.variables <- lapply(dummy.variables,
+                                        function(x) attr(.estimation.data[[x]], "predictors.matching.dummy"))
+            names(mapping.variables) <- dummy.variables
+            aliased.dummy.vars <- vapply(mapping.variables, function(x) length(x) > 1, logical(1))
+            if (any(aliased.dummy.vars))
+                aliasedDummyVariableWarning(data, mapping.variables, show.labels, predictor.names)
+            # Update formula to include dummy variables
             new.formulae <- updateDummyVariableFormulae(input.formula, formula.with.interaction,
                                                         data = processed.data$estimation.data)
             input.formula <- new.formulae$formula
             formula.with.interaction <- new.formulae$formula.with.interaction
         }
 
-        unfiltered.weights <- processed.data$unfiltered.weights
-        .estimation.data <- processed.data$estimation.data
+
 
         n <- nrow(.estimation.data)
         if (n < ncol(.estimation.data) + 1)
@@ -652,7 +663,7 @@ Regression <- function(formula = as.formula(NULL),
                      paste0(names(classes), collapse = ", "), " and re-run the analysis.")
             if (any(grepDummyVars(names(result$original$coefficients))))
             {
-                .estimation.data <- adjustDataMissingDummy(data, result$original, .estimation.data, interaction.name = interaction.name)
+                .estimation.data <- adjustDataMissingDummy(data, result$original, .estimation.data, show.labels)
                 input.formula <- updateDummyVariableFormulae(formula = input.formula, formula.with.interaction = NULL,
                                                              data = processed.data$estimation.data,
                                                              update.string = " - ")$formula
@@ -1896,8 +1907,14 @@ updateDummyVariableFormulae <- function(formula, formula.with.interaction, data,
 
 grepDummyVars <- function(string, dummy.pattern = ".dummy.var_GQ9KqD7YOf$") grepl(dummy.pattern, string)
 
+# Function to impute the missing values in original data to give the equivalent regression
+# coefficients to those generated in the dummy adjusted model.
+# Requires the original data, the fitted model to access the regression coefficients along with the
+# design matrix from the estimation.data and the show.labels logical value in case any warnings
+# are to be reported if the missing values caused aliased dummy predictors.
+#' @importFrom flipFormat Labels
 #' @importFrom stats terms.formula
-adjustDataMissingDummy <- function(data, model, estimation.data, interaction.name = "NULL")
+adjustDataMissingDummy <- function(data, model, estimation.data, show.labels)
 {
     model.formula <- formula(model)
     formula.terms <- terms(model.formula)
@@ -1911,8 +1928,30 @@ adjustDataMissingDummy <- function(data, model, estimation.data, interaction.nam
     data.for.means <- data[which(names(data) %in% predictor.names)]
     means.from.data <- lapply(data.for.means, function(x) {
         if (is.numeric(x)) mean(x, na.rm = TRUE) else NULL})
-    missing.replacements <- extractDummyAdjustedCoefs(model$coefficients, means.from.data)
-    missing.numeric <- sapply(names(missing.replacements), function(x) is.numeric(design.data[[x]]))
+    # Check if any aliasing of dummy variables has occurred, first extract mapping
+    dummy.variables <- names(estimation.data)[grepDummyVars(names(estimation.data))]
+    mapping.variables <- lapply(dummy.variables,
+                                function(x) attr(estimation.data[[x]], "predictors.matching.dummy"))
+    names(mapping.variables) <- dummy.variables
+    # dummy variables were aliased if mapping points to more than one original variable
+    aliased <- vapply(mapping.variables, function(x) length(x) > 1, logical(1))
+    if (any(aliased))
+    {
+        mapping.variables <- mapping.variables[aliased]
+        extra.coefs <- lapply(names(mapping.variables),
+                              function(x) {
+                                  vars <- mapping.variables[[x]][-1] # 1st element is redundant
+                                  y <- rep(model$coefficients[[x]], length(vars))
+                                  names(y) <- paste0(vars, ".dummy.var_GQ9KqD7YOf")
+                                  y
+                              })
+        model.coefs <- c(model$coefficients, unlist(extra.coefs))
+    } else
+        model.coefs <- model$coefficients
+    missing.replacements <- extractDummyAdjustedCoefs(model.coefs, means.from.data)
+    missing.numeric <- vapply(names(missing.replacements),
+                              function(x) is.numeric(design.data[[x]]),
+                              logical(1))
     for (pred.name in names(missing.numeric)[which(missing.numeric)])
     {
         x.col <- design.data[[pred.name]]
@@ -1927,6 +1966,55 @@ adjustDataMissingDummy <- function(data, model, estimation.data, interaction.nam
     new.data[["non.outlier.data_GQ9KqD7YOf"]] <- estimation.data[["non.outlier.data_GQ9KqD7YOf"]]
     new.data <- CopyAttributes(new.data, data)
     return(new.data)
+}
+
+# Gives an informative message to the user if there are any aliased dummy variables
+# data is the entire regression dataset with attributes if provided.
+# mapping.variables is the list showing the mapping from the dummy variables to the group of
+# predictors
+# show.labels is the logical used to print either names or labels in warning
+# predictor.names is the character vector of all predictor names used in data
+#' @importFrom flipFormat Labels ExtractCommonPrefix
+aliasedDummyVariableWarning <- function(data, mapping.variables, show.labels, predictor.names)
+{
+    all.mapped.variables <- unlist(mapping.variables, use.names = FALSE)
+    if (show.labels)
+    {
+        # Look up names from the full predictor set of names to ensure appropriate truncation
+        predictor.names <- predictor.names[!grepDummyVars(predictor.names)]
+        lbls <- Labels(data, names.to.lookup = predictor.names)
+        names(lbls) <- predictor.names
+        extracted <- ExtractCommonPrefix(lbls)
+        if (!is.na(extracted$common.prefix))
+            lbls <- extracted$shortened.labels
+        lbls <- lbls[names(lbls) %in% all.mapped.variables]
+    } else
+    { # Otherwise just use the names and retain the
+        lbls <- all.mapped.variables
+        names(lbls) <- all.mapped.variables
+    }
+    n.groups <- length(mapping.variables)
+    groups <- lapply(mapping.variables, function(x) paste0(lbls[x], collapse = "; "))
+    if (n.groups > 1)
+    {
+        groups <- lapply(1:n.groups, function(x) paste0("Group ", x, " (", groups[[x]], ")"))
+        groups <- unlist(groups)
+        group.msg <- paste0(paste0(groups[1:(n.groups - 1)], collapse = ""), " and ", groups[n.groups])
+        warning.msg <- paste0("Some groups of predictors have the exactly the same cases with ",
+                              "missing values and consequently, only a single dummy variable was ",
+                              "used to adjust the data for each group. ", group.msg, ". The dummy ",
+                              "variables would be aliased if each predictor in each group had ",
+                              "its own dummy variable.")
+    } else
+    {
+        group <- unlist(groups, use.names = FALSE)
+        warning.msg <- paste0("The following group of predictors have the exactly the same cases ",
+                              "with missing values and consequently, only a single dummy variable ",
+                              "was used to adjust the data: ", group, ". The dummy variables would ",
+                              "be aliased if each predictor in this group had its own dummy ",
+                              "variable.")
+    }
+    warning(warning.msg)
 }
 
 extractDummyAdjustedCoefs <- function(coefficients, computed.means)

--- a/R/regression.R
+++ b/R/regression.R
@@ -1999,7 +1999,7 @@ aliasedDummyVariableWarning <- function(data, mapping.variables, show.labels, pr
     {
         groups <- lapply(1:n.groups, function(x) paste0("Group ", x, " (", groups[[x]], ")"))
         groups <- unlist(groups)
-        group.msg <- paste0(paste0(groups[1:(n.groups - 1)], collapse = ""), " and ", groups[n.groups])
+        group.msg <- paste0(paste0(groups[1:(n.groups - 1)], collapse = ", "), " and ", groups[n.groups])
         warning.msg <- paste0("Some groups of predictors have the exactly the same cases with ",
                               "missing values and consequently, only a single dummy variable was ",
                               "used to adjust the data for each group. ", group.msg, ". The dummy ",
@@ -2008,11 +2008,10 @@ aliasedDummyVariableWarning <- function(data, mapping.variables, show.labels, pr
     } else
     {
         group <- unlist(groups, use.names = FALSE)
-        warning.msg <- paste0("The following group of predictors have the exactly the same cases ",
-                              "with missing values and consequently, only a single dummy variable ",
-                              "was used to adjust the data: ", group, ". The dummy variables would ",
-                              "be aliased if each predictor in this group had its own dummy ",
-                              "variable.")
+        warning.msg <- paste0("The ", group, " predictors have exactly the same cases with missing ",
+                              "values and consequently, only a single dummy variable was used to ",
+                              "adjust the data for these predictors. The dummy variables would be ",
+                              "aliased if each predictor in this group had its own dummy variable.")
     }
     warning(warning.msg)
 }

--- a/tests/testthat/test-dummyvariableadjustment.R
+++ b/tests/testthat/test-dummyvariableadjustment.R
@@ -142,11 +142,13 @@ test_that("DS-2952: Dummy variable adjustment and Ordered Logit printable in RIA
 })
 
 test_that("DS-2986: Aliased Dummy variables", {
-    X <- MASS::mvrnorm(n = 200, mu = rep(0, 4), Sigma = matrix(c(1, 0.2, 0.3, 0.2,
-                                                                 0.2, 1, 0.2, 0.3,
-                                                                 0.3, 0.2, 1, 0.4,
-                                                                 0.2, 0.3, 0.4, 1), ncol = 4))
-    beta <- c(0.4, 0.3, 0.25, 0.3)
+    X <- MASS::mvrnorm(n = 200, mu = rep(0, 6), Sigma = matrix(c(1, 0.2, 0.3, 0.2, 0.3, 0.4,
+                                                                 0.2, 1, 0.2, 0.3, 0.4, 0.5,
+                                                                 0.3, 0.2, 1, 0.4, 0.5, 0.2,
+                                                                 0.2, 0.3, 0.4, 1, 0.2, 0.3,
+                                                                 0.3, 0.4, 0.5, 0.2, 1, 0.1,
+                                                                 0.4, 0.5, 0.2, 0.3, 0.1, 1), ncol = 6))
+    beta <- c(0.4, 0.3, 0.25, 0.3, 0.2, 0.1)
     r2 <- 0.30
 
     Y <- X %*% beta + rnorm(n = 200)
@@ -168,20 +170,72 @@ test_that("DS-2986: Aliased Dummy variables", {
             y[second.common] <- NA
         y
     }))
-    names(one.group.aliased) <- names(two.groups.aliased) <- names(not.missing.data)
-    expect_warning(dummy.regression <- Regression(Y ~ X1 + X2 + X3, data = one.group.aliased,
-                                                  missing = "Dummy variable adjustment"),
-                   paste0("The following group of predictors have the exactly the same cases with ",
-                          "missing values and consequently, only a single dummy variable was used ",
-                          "to adjust the data: X1; X2. The dummy variables would be aliased if ",
+    third.common <- sample(c(TRUE, FALSE), size = nrow(X), replace = TRUE, prob = c(1, 4))
+    three.groups.aliased <- data.frame(lapply(1:ncol(not.missing.data), function(x) {
+        y <- not.missing.data[[x]]
+        if (x %in% 2:3) # Ignore Y and last X
+            y[common.indices] <- NA
+        else if (x %in% 4:5)
+            y[second.common] <- NA
+        else if (x %in% 6:7)
+            y[third.common] <- NA
+        y
+    }))
+    names(one.group.aliased) <- names(two.groups.aliased) <- names(three.groups.aliased) <- names(not.missing.data)
+    expect_warning(Regression(Y ~ X1 + X2 + X3, data = one.group.aliased,
+                              missing = "Dummy variable adjustment"),
+                   paste0("The X1; X2 predictors have exactly the same cases with missing values ",
+                          "and consequently, only a single dummy variable was used to adjust the ",
+                          "data for these predictors. The dummy variables would be aliased if ",
                           "each predictor in this group had its own dummy variable."),
                    fixed = TRUE)
-    expect_warning(dummy.regression <- Regression(Y ~ X1 + X2 + X3 + X4, data = two.groups.aliased,
-                                                  missing = "Dummy variable adjustment"),
+    labelled.one.group <- one.group.aliased
+    attr(labelled.one.group$X1, "label") <- "Apples"
+    attr(labelled.one.group$X2, "label") <- "Oranges"
+    expect_warning(Regression(Y ~ X1 + X2 + X3, data = labelled.one.group, show.labels = TRUE,
+                              missing = "Dummy variable adjustment"),
+                   paste0("The Apples; Oranges predictors have exactly the same cases with missing values ",
+                          "and consequently, only a single dummy variable was used to adjust the ",
+                          "data for these predictors. The dummy variables would be aliased if ",
+                          "each predictor in this group had its own dummy variable."),
+                   fixed = TRUE)
+    expect_warning(Regression(Y ~ X1 + X2 + X3 + X4, data = two.groups.aliased,
+                              missing = "Dummy variable adjustment"),
                    paste0("Some groups of predictors have the exactly the same cases with missing ",
                           "values and consequently, only a single dummy variable was used to ",
                           "adjust the data for each group. Group 1 (X1; X2) and Group 2 (X3; X4). ",
                           "The dummy variables would be aliased if each predictor in each group ",
                           "had its own dummy variable."),
+                   fixed = TRUE)
+    labelled.two.groups <- two.groups.aliased
+    attr(labelled.two.groups$X1, "label") <- "Apples"
+    attr(labelled.two.groups$X3, "label") <- "Oranges"
+    expect_warning(Regression(Y ~ X1 + X2 + X3 + X4, data = labelled.two.groups, show.labels = TRUE,
+                              missing = "Dummy variable adjustment"),
+                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                          "values and consequently, only a single dummy variable was used to ",
+                          "adjust the data for each group. Group 1 (Apples; X2) and Group 2 ",
+                          "(Oranges; X4). The dummy variables would be aliased if each predictor ",
+                          "in each group had its own dummy variable."),
+                   fixed = TRUE)
+    expect_warning(Regression(Y ~ X1 + X2 + X3 + X4 + X5 + X6, data = three.groups.aliased,
+                              missing = "Dummy variable adjustment"),
+                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                          "values and consequently, only a single dummy variable was used to ",
+                          "adjust the data for each group. Group 1 (X1; X2), Group 2 (X3; X4) and ",
+                          "Group 3 (X5; X6). The dummy variables would be aliased if each ",
+                          "predictor in each group had its own dummy variable."),
+                   fixed = TRUE)
+    labelled.three.groups <- three.groups.aliased
+    attr(labelled.three.groups$X1, "label") <- "Apples"
+    attr(labelled.three.groups$X3, "label") <- "Oranges"
+    attr(labelled.three.groups$X5, "label") <- "Grapes"
+    expect_warning(Regression(Y ~ X1 + X2 + X3 + X4 + X5 + X6, data = labelled.three.groups,
+                              show.labels = TRUE, missing = "Dummy variable adjustment"),
+                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                          "values and consequently, only a single dummy variable was used to ",
+                          "adjust the data for each group. Group 1 (Apples; X2), Group 2 (Oranges; ",
+                          "X4) and Group 3 (Grapes; X6). The dummy variables would be aliased if ",
+                          "each predictor in each group had its own dummy variable."),
                    fixed = TRUE)
 })

--- a/tests/testthat/test-dummyvariableadjustment.R
+++ b/tests/testthat/test-dummyvariableadjustment.R
@@ -140,3 +140,48 @@ test_that("DS-2952: Dummy variable adjustment and Ordered Logit printable in RIA
                  NA)
     expect_error(print(model), NA)
 })
+
+test_that("DS-2986: Aliased Dummy variables", {
+    X <- MASS::mvrnorm(n = 200, mu = rep(0, 4), Sigma = matrix(c(1, 0.2, 0.3, 0.2,
+                                                                 0.2, 1, 0.2, 0.3,
+                                                                 0.3, 0.2, 1, 0.4,
+                                                                 0.2, 0.3, 0.4, 1), ncol = 4))
+    beta <- c(0.4, 0.3, 0.25, 0.3)
+    r2 <- 0.30
+
+    Y <- X %*% beta + rnorm(n = 200)
+
+    not.missing.data <- data.frame(Y, X)
+    common.indices <- sample(c(TRUE, FALSE), size = nrow(X), replace = TRUE, prob = c(1, 4))
+    one.group.aliased <- data.frame(lapply(1:ncol(not.missing.data), function(x) {
+        y <- not.missing.data[[x]]
+        if (x %in% 2:3) # Ignore Y and last X
+            y[common.indices] <- NA
+        y
+    }))
+    second.common <- sample(c(TRUE, FALSE), size = nrow(X), replace = TRUE, prob = c(1, 4))
+    two.groups.aliased <- data.frame(lapply(1:ncol(not.missing.data), function(x) {
+        y <- not.missing.data[[x]]
+        if (x %in% 2:3) # Ignore Y and last X
+            y[common.indices] <- NA
+        else if (x %in% 4:5)
+            y[second.common] <- NA
+        y
+    }))
+    names(one.group.aliased) <- names(two.groups.aliased) <- names(not.missing.data)
+    expect_warning(dummy.regression <- Regression(Y ~ X1 + X2 + X3, data = one.group.aliased,
+                                                  missing = "Dummy variable adjustment"),
+                   paste0("The following group of predictors have the exactly the same cases with ",
+                          "missing values and consequently, only a single dummy variable was used ",
+                          "to adjust the data: X1; X2. The dummy variables would be aliased if ",
+                          "each predictor in this group had its own dummy variable."),
+                   fixed = TRUE)
+    expect_warning(dummy.regression <- Regression(Y ~ X1 + X2 + X3 + X4, data = two.groups.aliased,
+                                                  missing = "Dummy variable adjustment"),
+                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                          "values and consequently, only a single dummy variable was used to ",
+                          "adjust the data for each group. Group 1 (X1; X2) and Group 2 (X3; X4). ",
+                          "The dummy variables would be aliased if each predictor in each group ",
+                          "had its own dummy variable."),
+                   fixed = TRUE)
+})

--- a/tests/testthat/test-dummyvariableadjustment.R
+++ b/tests/testthat/test-dummyvariableadjustment.R
@@ -201,7 +201,7 @@ test_that("DS-2986: Aliased Dummy variables", {
                    fixed = TRUE)
     expect_warning(Regression(Y ~ X1 + X2 + X3 + X4, data = two.groups.aliased,
                               missing = "Dummy variable adjustment"),
-                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                   paste0("Some groups of predictors have exactly the same cases with missing ",
                           "values and consequently, only a single dummy variable was used to ",
                           "adjust the data for each group. Group 1 (X1; X2) and Group 2 (X3; X4). ",
                           "The dummy variables would be aliased if each predictor in each group ",
@@ -212,7 +212,7 @@ test_that("DS-2986: Aliased Dummy variables", {
     attr(labelled.two.groups$X3, "label") <- "Oranges"
     expect_warning(Regression(Y ~ X1 + X2 + X3 + X4, data = labelled.two.groups, show.labels = TRUE,
                               missing = "Dummy variable adjustment"),
-                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                   paste0("Some groups of predictors have exactly the same cases with missing ",
                           "values and consequently, only a single dummy variable was used to ",
                           "adjust the data for each group. Group 1 (Apples; X2) and Group 2 ",
                           "(Oranges; X4). The dummy variables would be aliased if each predictor ",
@@ -220,7 +220,7 @@ test_that("DS-2986: Aliased Dummy variables", {
                    fixed = TRUE)
     expect_warning(Regression(Y ~ X1 + X2 + X3 + X4 + X5 + X6, data = three.groups.aliased,
                               missing = "Dummy variable adjustment"),
-                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                   paste0("Some groups of predictors have exactly the same cases with missing ",
                           "values and consequently, only a single dummy variable was used to ",
                           "adjust the data for each group. Group 1 (X1; X2), Group 2 (X3; X4) and ",
                           "Group 3 (X5; X6). The dummy variables would be aliased if each ",
@@ -232,7 +232,7 @@ test_that("DS-2986: Aliased Dummy variables", {
     attr(labelled.three.groups$X5, "label") <- "Grapes"
     expect_warning(Regression(Y ~ X1 + X2 + X3 + X4 + X5 + X6, data = labelled.three.groups,
                               show.labels = TRUE, missing = "Dummy variable adjustment"),
-                   paste0("Some groups of predictors have the exactly the same cases with missing ",
+                   paste0("Some groups of predictors have exactly the same cases with missing ",
                           "values and consequently, only a single dummy variable was used to ",
                           "adjust the data for each group. Group 1 (Apples; X2), Group 2 (Oranges; ",
                           "X4) and Group 3 (Grapes; X6). The dummy variables would be aliased if ",


### PR DESCRIPTION
When Dummy Variable Adjustment is used in Regression, it needs to check for 
predictors that have identical structure in their missing values. This 
PR handles the deduplicated dummy variables handled by flipData and warns the 
user if any dummy variables are aliased. It also correctly remaps the data suitable
for RIA/Shapley.

- DS-2986 Handle aliased dummy variables
- DS-2986 Add unit tests for aliased dummy vars
- DS-2986 Point to flipData@DS-2986 in .travis.yml
