### PR TITLE
DS-3195 Refactor to check valid formula names earlier

### DIFF
--- a/R/crosstabinteraction.R
+++ b/R/crosstabinteraction.R
@@ -67,7 +67,7 @@ computeInteractionCrosstab <- function(result, interaction.name, interaction.lab
     if (!is.null(importance))
     {
         importance.scores <- result$importance$importance
-        var.names <- result$importance.names
+        var.names <- result$importance.names[!grepDummyVars(result$importance.names)]
         var.labels <- result$importance.labels
         res$net.coef <- importance.scores
         num.var <- length(importance.scores)

--- a/R/data.R
+++ b/R/data.R
@@ -312,27 +312,6 @@ validateDataForRIA <- function(input.formula, estimation.data, outcome.name, sho
 {
     # Check to see if there are columns with no variation
     validateVariablesHaveVariation(input.formula, estimation.data, outcome.name, output, show.labels, group.name)
-    # Remove any dataset references e.g. mydata$Variables$Y since this breaks the later call to alias.
-    if (any(vars.to.relabel <- checkFormulaForValidNames(input.formula, data = estimation.data,
-                                                         patt = dataset.reference.patt)))
-    {
-        new.var.names <- makeVariableNamesValid(vars.to.relabel, remove.patt = dataset.reference.patt)
-        relabelled.outputs <- relabelFormulaAndData(new.var.names, input.formula, estimation.data)
-        input.formula <- relabelled.outputs$formula
-        estimation.data <- relabelled.outputs$data
-        outcome.name <- relabelled.outputs$outcome.name
-    }
-    # Check names are syntactic for formula and data, if non-syntactic, make them that way.
-    variable.names <- AllVariablesNames(input.formula, data = estimation.data)
-    syntactic.names <- make.names(variable.names, unique = TRUE)
-    if (!identical(variable.names, syntactic.names))
-    {
-        names(syntactic.names) <- variable.names
-        relabelled.outputs <- relabelFormulaAndData(syntactic.names, input.formula, estimation.data)
-        input.formula <- relabelled.outputs$formula
-        estimation.data <- relabelled.outputs$data
-        outcome.name <- relabelled.outputs$outcome.name
-    }
     # Check to see if there are linearly dependent predictors
     aliased.processed <- determineAliased(input.formula, estimation.data, outcome.name)
     if (is(aliased.processed, "list"))
@@ -463,4 +442,16 @@ relabelFormulaAndData <- function(new.var.names, formula, data)
     cols.to.update <- match(names(new.var.names), colnames(data), nomatch = 0)
     names(data)[cols.to.update] <- new.var.names
     list(formula = formula, data = data, outcome.name = unname(outcome.name))
+}
+
+checkForNonSyntacticNames <- function(input.formula, data)
+{
+    variable.names <- AllVariablesNames(input.formula, data = data)
+    syntactic.names <- make.names(variable.names, unique = TRUE)
+    if (non.syntactic.names <- !identical(variable.names, syntactic.names))
+    {
+        names(syntactic.names) <- variable.names
+        return(syntactic.names)
+    }
+    return(NULL)
 }

--- a/tests/testthat/test-dataproblems.R
+++ b/tests/testthat/test-dataproblems.R
@@ -508,7 +508,7 @@ test_that("DS-2990: Helper functions detecting dataset references in formula", {
     expect_equal(unname(long.lm$coef), unname(cleaned.lm$coef))
 })
 
-test_that("Non-syntactic names in formula for alias checking in RIA", {
+test_that("Non-syntactic names in formula", {
     bad.formula <- `Q1#A` ~ X.1 + X.2 + X.3
     sigma.mat <- matrix(c(1, 0.5, 0.3,
                           0.5, 1, 0.4,
@@ -517,10 +517,13 @@ test_that("Non-syntactic names in formula for alias checking in RIA", {
     dat <- data.frame(X = X)
     dat$Y <- runif(nrow(dat))
     names(dat)[4] <- "`Q1#A`"
-    expect_error(flipRegression:::validateDataForRIA(bad.formula,
-                                                     estimation.data = dat,
-                                                     outcome.name = "`Q1#A`",
-                                                     show.labels = TRUE,
-                                                     output = "Shapley Regression"),
-                 NA)
+    expected.mapping <- c("X.Q1.A.", X.1 = "X.1", X.2 = "X.2", X.3 = "X.3")
+    names(expected.mapping)[1] <- "`Q1#A`"
+    expect_equal(flipRegression:::checkForNonSyntacticNames(input.formula = bad.formula,
+                                                            data = dat),
+                 expected.mapping)
+    good.formula <- Y ~ X.1 + X.2 + X.3
+    names(dat)[4] <- "Y"
+    expect_null(flipRegression:::checkForNonSyntacticNames(input.formula = good.formula,
+                                                           data = dat))
 })


### PR DESCRIPTION
Formulae are fragile when used with non-syntactic names. The checks are moved to
early in the call to Regression to prevent later issues and tidy the code later