### PR TITLE
DS-3582 Correctly point to design when outliers removed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.43
+Version: 1.3.44
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project

--- a/R/crosstabinteraction.R
+++ b/R/crosstabinteraction.R
@@ -86,7 +86,7 @@ computeInteractionCrosstab <- function(result, interaction.name, interaction.lab
     ss <- matrix(NA, num.var, num.split, dimnames=list(var.names, NULL))
     sc <- matrix(NA, num.var, num.split, dimnames=list(var.names, NULL))
     result$estimation.data[["non.outlier.data_GQ9KqD7YOf"]] <- NULL
-    outlier.prop.to.remove <- if (outliers.removed) result$call[["outlier.prop.to.remove"]]
+    outlier.prop.to.remove <- if (outliers.removed) result[["outlier.prop.to.remove"]]
                               else 0L
     if (!is.null(importance))
     {

--- a/R/regression.R
+++ b/R/regression.R
@@ -1078,7 +1078,7 @@ FitRegression <- function(.formula, .estimation.data, .weights, type, robust.se,
                                                          type, robust.se, outlier.prop.to.remove, seed = seed,...)
         model <- refitted.model.data$model
         .estimation.data <- refitted.model.data$.estimation.data
-        .design <- refitted.model.data$.design
+        .design <- refitted.model.data$design
         non.outlier.data <- refitted.model.data$non.outlier.data
     } else
         non.outlier.data <- rep(TRUE, nrow(.estimation.data))


### PR DESCRIPTION
* Bugfix: Output list of the refitting regression function without
  outliers would give a NULL reference to the design due to a typo
* Added unit tests to cross tab interaction to explore this situation
  more deeply.
