### PR TITLE
DS-3707: Use updated formula in MI recursion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.47
+Version: 1.3.48
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project

--- a/R/regression.R
+++ b/R/regression.R
@@ -579,7 +579,7 @@ Regression <- function(formula = as.formula(NULL),
         if (missing == "Multiple imputation")
         {
             models <- lapply(processed.data$estimation.data,
-                             FUN = function(x) Regression(formula,
+                             FUN = function(x) Regression(input.formula,
                                                           data = x,                               # contains interaction factor; filters already applied
                                                           missing = "Error if missing data",
                                                           weights = processed.data$weights,


### PR DESCRIPTION
* When non-syntactic names or data set names are included in the
regression formula, we update input.formula and the names in data
but not formula. Multiple imputation was recursively calling Regression
with formula instead of input.formula resulting in a mismatch with the
names in data