### PR TITLE
EH-623: Add tests for forward Stepwise with sim. data

### DIFF
--- a/tests/testthat/test-stepwise.R
+++ b/tests/testthat/test-stepwise.R
@@ -67,3 +67,98 @@ test_that("Forward stepwise with robust standard errors (DS-2978)", {
                                                 robust.se = TRUE))
     expect_error(Stepwise(linear.model, direction = "Forward"), NA)
 })
+
+## https://github.com/ryantibs/best-subset/bestsubset
+enlist <- function (...)
+{
+    result <- list(...)
+    if ((nargs() == 1) & is.character(n <- result[[1]])) {
+        result <- as.list(seq(n))
+        names(result) <- n
+        for (i in n) result[[i]] <- get(i)
+    }
+    else {
+        n <- sys.call()
+        n <- as.character(n)[-1]
+        if (!is.null(n2 <- names(result))) {
+            which <- n2 != ""
+            n[which] <- n2[which]
+        }
+        names(result) <- n
+    }
+    result
+}
+
+## Simulation setup based on "Best subset selection via a modern
+## optimization lens" by Dimitris Bertsimas, Angela King, and Rahul
+## Mazumder, Annals of Statistics, 44(2), 813-852, 2016.
+## Code source: \url{https://github.com/ryantibs/best-subset/bestsubset}
+## The data model is: Y \sim N(Xbeta, sigma^2 I).  The predictor
+## variables have covariance matrix Sigma, with (i,j)th entry
+## rho^abs(i-j). The error variance sigma^2 is set according to the
+## desired signal-to-noise ratio. The first 4 options for the nonzero
+## pattern of the underlying regression coefficients beta follow the
+## simulation setup in Bertsimas, King, and Mazumder (2016), and the
+## 5th is a weak sparsity option:
+##    • 1: beta has s components of 1, occurring at (roughly)
+##      equally-spaced indices in between 1 and p
+##    • 2: beta has its first s components equal to 1
+##    • 3: beta has its first s components taking nonzero values,
+##      where the decay in a linear fashion from 10 to 0.5
+##    • 4: beta has its first 6 components taking the nonzero values
+##      -10,-6, -2,2,6,10
+##    • 5: beta has its first s components equal to 1, and the rest
+##      decaying to zero at an exponential rate
+sim.xy <- function (n, p, nval, rho = 0, s = 5, beta.type = 1, snr = 1)
+{
+    x = matrix(rnorm(n * p), n, p)
+    xval = matrix(rnorm(nval * p), nval, p)
+    if (rho != 0) {
+        inds = 1:p
+        Sigma = rho^abs(outer(inds, inds, "-"))
+        obj = svd(Sigma)
+        Sigma.half = obj$u %*% (sqrt(diag(obj$d))) %*% t(obj$v)
+        x = x %*% Sigma.half
+        xval = xval %*% Sigma.half
+    }
+    else Sigma = diag(1, p)
+    s = min(s, p)
+    beta = rep(0, p)
+    if (beta.type == 1) {
+        beta[round(seq(1, p, length = s))] = 1
+    }
+    else if (beta.type == 2) {
+        beta[1:s] = 1
+    }
+    else if (beta.type == 3) {
+        beta[1:s] = seq(10, 0.5, length = s)
+    }
+    else if (beta.type == 4) {
+        beta[1:6] = c(-10, -6, -2, 2, 6, 10)
+    }
+    else {
+        beta[1:s] = 1
+        beta[(s + 1):p] = 0.5^(1:(p - s))
+    }
+    vmu = as.numeric(t(beta) %*% Sigma %*% beta)
+    sigma = sqrt(vmu/snr)
+    y = as.numeric(x %*% beta + rnorm(n) * sigma)
+    yval = as.numeric(xval %*% beta + rnorm(nval) * sigma)
+    enlist(x, y, xval, yval, Sigma, beta, sigma)
+}
+
+test_that("EH-623: Simulation study of fwrd-stepwise reg. using bestsubset pkg",
+{
+    set.seed(2)
+    dat <- sim.xy(n = 1000, p = 10, nval = 0, rho = 0, s = 3, beta.type = 1, snr = 4)
+    df <- as.data.frame(cbind(y = dat$y, dat$x))
+    pred.names <- colnames(df)[-1]
+
+    included.expected <- pred.names[dat$beta > 0]
+    excluded.expected <- setdiff(pred.names, included.expected)
+    ## Stepwise does not work with '.' on RHS of formula
+    form <- as.formula(paste0("y~", paste(pred.names, collapse = "+")))
+    reg.out <- Regression(form, data = df)
+    stepwise.out <- Stepwise(reg.out, direction = "Forward")
+    expect_setequal(stepwise.out$excluded, excluded.expected)
+})


### PR DESCRIPTION
* Add initial unit tests on synthetic data using simulation setup from https://arxiv.org/abs/1707.08692 for forward stepwise multiple linear regression