### PR TITLE
RS-17733 Robustly impute data when using Dummy Variable adjustment for RIA / Shapley regression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.64
+Version: 1.3.65
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project

--- a/R/regression.R
+++ b/R/regression.R
@@ -2351,7 +2351,10 @@ extractDummyAdjustedCoefs <- function(coefficients, computed.means)
     dummy.values <- as.list(coefficients[dummy.variables])
     names(dummy.values) <- dummy.variable.names
     adjusted.vals <- lapply(dummy.variable.names, function(x) {
-        computed.means[[x]] + dummy.values[[x]]/slope.values[[x]]})
+        adjustment <- computed.means[[x]]
+        if (!is.na(dummy.values[[x]])) adjustment <- adjustment + dummy.values[[x]]/slope.values[[x]]
+        adjustment
+    })
     names(adjusted.vals) <- dummy.variable.names
     return(adjusted.vals)
 }

--- a/R/regression.R
+++ b/R/regression.R
@@ -2360,7 +2360,7 @@ extractImputedValuesFromDummyAdjustments <- function(coefficients, computed.mean
 {
     dummy.variables <- isDummyVariable(names(coefficients))
     dummy.variable.names <- extractDummyNames(names(coefficients)[dummy.variables])
-    standard.variables <- grepl(paste0("^", dummy.variable.names, "$", collapse = "|"), names(coefficients))
+    standard.variables <- dummy.variable.names %in% names(coefficients)
     standard.variable.names <- names(coefficients)[standard.variables]
     slope.values <- as.list(coefficients[standard.variables])
     names(slope.values) <- standard.variable.names

--- a/R/regression.R
+++ b/R/regression.R
@@ -2273,7 +2273,7 @@ adjustDataMissingDummy <- function(data, model, estimation.data, show.labels)
     }
     # Apply filter since one of the predictors may have been removed from the model as its colinear
     # and a dummy variable might be linked to it (it wont have a slope coefficient, so it will have length zero)
-    missing.replacements <- Filter(length, extractDummyAdjustedCoefs(model.coefs, means.from.data))
+    missing.replacements <- Filter(length, extractImputedValuesFromDummyAdjustments(model.coefs, means.from.data))
     missing.numeric <- vapply(names(missing.replacements),
                               function(x) is.numeric(design.data[[x]]),
                               logical(1))
@@ -2340,7 +2340,23 @@ aliasedDummyVariableWarning <- function(data, mapping.variables, show.labels, pr
     warning(warning.msg)
 }
 
-extractDummyAdjustedCoefs <- function(coefficients, computed.means)
+# The values extracted here will allow missing values to be imputed and the predictions
+# using only the standard predictors from the dummy adjusted model (not using dummy adjustment
+# coefficients) will produce the same values as the original data using the full set of
+# predictors (including dummy variable predictors). This is used to prepare a dataset
+# for relative importance analysis as it requires complete data.
+# It returns a vector of imputed values for each predictor in the dataset.
+# If dummy adjusted fit: Y_d = X_d beta_d + eps
+# then fitted Y_d = beta_0 + xbar * beta_x + beta_d where
+#  - xbar = mean of x
+#  - beta_x = slope for x
+#  - beta_d = dummy adjusted variable slope
+# For imputation then equality is needed for the predictor value for the standard set
+# of predictors and the mean used in the full dummy adjusted model.
+# That is,
+#   x beta_x = beta_x xbar + beta_d
+#   => x = xbar + beta_d / beta_x
+extractImputedValuesFromDummyAdjustments <- function(coefficients, computed.means)
 {
     dummy.variables <- isDummyVariable(names(coefficients))
     dummy.variable.names <- extractDummyNames(names(coefficients)[dummy.variables])
@@ -2352,7 +2368,10 @@ extractDummyAdjustedCoefs <- function(coefficients, computed.means)
     names(dummy.values) <- dummy.variable.names
     adjusted.vals <- lapply(dummy.variable.names, function(x) {
         adjustment <- computed.means[[x]]
-        if (!is.na(dummy.values[[x]])) adjustment <- adjustment + dummy.values[[x]]/slope.values[[x]]
+        # A dummy adjustment variable slope might be aliased and its not possible to adjust the slope
+        # The adjustment is not required as it isnt used in the dummy adjustment model. So the
+        # imputed value is just the mean
+        if (!is.na(dummy.values[[x]])) adjustment <- adjustment + dummy.values[[x]] / slope.values[[x]]
         adjustment
     })
     names(adjusted.vals) <- dummy.variable.names

--- a/tests/testthat/test-dummyvariableadjustment.R
+++ b/tests/testthat/test-dummyvariableadjustment.R
@@ -27,7 +27,7 @@ test_that("Coefficient estimates are the same ", {
     computed.means <- lapply(missing.data, mean, na.rm = TRUE)
 
     # Check extracted Coefs correct, they will be the last three of the regular coefficients
-    dummy.adjusted.coefs <- extractDummyAdjustedCoefs(all.coefs, computed.means)
+    dummy.adjusted.coefs <- extractImputedValuesFromDummyAdjustments(all.coefs, computed.means)
 
     expect_equal(names(dummy.adjusted.coefs), c("X1", "X2", "X3"))
 
@@ -70,6 +70,18 @@ test_that("Coefficient estimates are the same ", {
     # Expect coefficients to be the same between original dummy adjusted regression and
     # on the remapped dataset.
     expect_equal(lm(Y ~ X1 + X2 + X3, data = remapped.data)$coef, all.coefs[-(5:7)])
+
+    # Aliased dummy variable predictors are handled
+    coefficients.with.dummy.aliased <- c(
+        `(Intercept)` = 0.5,
+        X1 = 0.4,
+        X2 = 0.3,
+        X1.dummy.var_GQ9KqD7YOf = NA,
+        X2.dummy.var_GQ9KqD7YOf = 0.6
+    )
+    computed.means <- c(X1 = 1, X2 = 2)
+    extractImputedValuesFromDummyAdjustments(coefficients.with.dummy.aliased, computed.means) |>
+        expect_equal(list(X1 = 1, X2 = 2 + 0.6 / 0.3))
 })
 
 test_that("Robust SE compatible with Dummy variable adjustment", {


### PR DESCRIPTION
Handle the case when a dummy variable predictor is aliased (NA), without this fix the
imputation conducted before RIA / Shapley will have NA values in the data and this will
error in an ugly way. The Imputation is handled properly with the fix and RIA / Shapley
can proceed.
