### PR TITLE
 Untracked: Handle edge case of single predictor for use partial data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.65
+Version: 1.3.66
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project

--- a/R/regression.R
+++ b/R/regression.R
@@ -504,6 +504,12 @@ Regression <- function(formula = NULL,
         formula <- input.formula <- missing.variable.adjustment[["formula"]]
         formula.with.interaction <- missing.variable.adjustment[["formula.with.interaction"]]
     }
+    if (length(AllVariablesNames(formula, data)) == 2L && missing == "Use partial data (pairwise correlations)") {
+        partial <- FALSE
+        missing <- "Exclude cases with missing data"
+        warning("Only a single predictor variable with non-missing values has been provided for analysis. ",
+                "The missing data option has been changed to Exclude cases with missing data")
+    }
 
     if (type == "Binary Logit" || output == "Jaccard Coefficient")
     {
@@ -555,7 +561,7 @@ Regression <- function(formula = NULL,
         subset <- CleanSubset(subset, nrow(data))
         unfiltered.weights <- weights <- CleanWeights(weights)
         result <- list(original = LinearRegressionFromCorrelations(input.formula, data, subset,
-                                                                   weights, outcome.name, ...),
+                                                                   weights, ...),
                        outliers.removed = !is.null(outlier.prop.to.remove) && outlier.prop.to.remove != 0,
                        call = cl)
         result$sample.description <- result$original$sample.description

--- a/R/regressionsweep.R
+++ b/R/regressionsweep.R
@@ -64,7 +64,7 @@ LinearRegressionFromCorrelations <- function(formula, data = NULL, subset = NULL
         for (c in 1:r)
         {
             pairwise.data <- !is.na(y.and.x[,c]) & !is.na(y.and.x[,r])
-            pairwise.n[r, c] <- if(weighted) Sum(weights[pairwise.data]) else Sum(pairwise.data)
+            pairwise.n[r, c] <- if (weighted) Sum(weights[pairwise.data]) else Sum(pairwise.data)
         }
     min.pairwise.n <- min(pairwise.n, na.rm = TRUE)
     cors <- if (weighted)
@@ -414,4 +414,3 @@ regressionFromCorrelations <- function(y, x, weights = rep(1, nrow(x)), b = 999)
 #         setCor.diagram(set.cor, main = main)
 #     return(set.cor)
 # }
-

--- a/tests/testthat/test-multipleimputation.R
+++ b/tests/testthat/test-multipleimputation.R
@@ -112,8 +112,10 @@ test_that("Other examples",
     # Complete case
     expect_error(Regression(price ~ distance, data = data.frame(distance, price)), NA)
 
-    expect_error(Regression(price ~ distance, data = data.frame(distance, price), missing = "Use partial data (pairwise correlations)"), NA)
-    expect_error(Regression(price ~ distance, data = data.frame(distance, price)[1:6, ], missing = "Use partial data (pairwise correlations)"), NA)
+    Regression(price ~ distance, data = data.frame(distance, price), missing = "Use partial data (pairwise correlations)") |>
+        expect_warning("Only a single predictor variable with non-missing values has been provided for analysis. ", fixed = TRUE)
+    Regression(price ~ distance, data = data.frame(distance, price)[1:6, ], missing = "Use partial data (pairwise correlations)") |>
+        expect_warning("Only a single predictor variable with non-missing values has been provided for analysis. ", fixed = TRUE)
 
     # Regression-based imputation
     expect_error(Regression(price ~ distance, data = data.frame(distance, price), missing = "Multiple imputation"), NA)

--- a/tests/testthat/test-regressionsweep.R
+++ b/tests/testthat/test-regressionsweep.R
@@ -18,8 +18,9 @@ test_that("Check for NAs in correlation matrix",
                                                        missing = "Use partial data (pairwise correlations)")))
               expect_error(suppressWarnings(Regression(y ~ x + z, data = df,
                                                        missing = "Use partial data (pairwise correlations)")))
-              expect_error(suppressWarnings(Regression(y ~ j, data = df,
-                                                       missing = "Use partial data (pairwise correlations)")))
+              Regression(y ~ j, data = df,
+                         missing = "Use partial data (pairwise correlations)") |>
+                  expect_warning("Only a single predictor variable with non-missing values has been provided for analysis")
           })
 
 


### PR DESCRIPTION
Change to Exclude cases with missing data and warn if use partial data is used with single predictor.
