### PR TITLE
DS-5479: Fix shapley code to allow RcppEigen upgrade

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegression
 Type: Package
 Title: Estimates standard regression models
-Version: 1.3.66
+Version: 1.3.67
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Regression models according to the flip Project
@@ -51,7 +51,7 @@ Remotes:
  Displayr/rhtmlHeatmap,
  Displayr/verbs,
 LinkingTo: Rcpp (>= 0.12.15),
- RcppEigen (<= 0.3.3.9.4)
+ RcppEigen
 VignetteBuilder: knitr
 RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/src/shapley.cpp
+++ b/src/shapley.cpp
@@ -73,10 +73,10 @@ double regressorSubsetRsquared(NumericVector combination_indices,
 
     for (int i = 0; i < combination_size; i++)
         for (int j = 0; j < combination_size; j++)
-            corr_regressors_submatrix(i, j) = corr_regressors(combination_indices[i],
-                                      combination_indices[j]);
+            corr_regressors_submatrix(i, j) = corr_regressors(static_cast<int>(combination_indices[i]),
+                                      static_cast<int>(combination_indices[j]));
     for (int i = 0; i < combination_size; i++)
-        corr_xy_subvector[i] = corr_xy[combination_indices[i]];
+        corr_xy_subvector[i] = corr_xy[static_cast<int>(combination_indices[i])];
 
     // v'M^1v, where v = corr_xy_subvector and M = corr_regressors_submatrix
     return (double)(corr_regressors_submatrix.llt().solve(corr_xy_subvector).dot(corr_xy_subvector));
@@ -176,4 +176,3 @@ NumericVector shapleyImportance(Eigen::MatrixXd & corr_regressors,
 
     return importance;
 }
-


### PR DESCRIPTION
Fixes the build issue of the shapley C++ code with the new RcppEigen dependency. Will allow RcppEigen to be unpinned.